### PR TITLE
Escape curly braces correctly in translation strings; remove default empty translation fallback in the text component

### DIFF
--- a/core/src/main/java/org/geysermc/geyser/text/MinecraftTranslationRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/text/MinecraftTranslationRegistry.java
@@ -28,6 +28,7 @@ package org.geysermc.geyser.text;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.geyser.translator.text.MessageTranslator;
 
 import java.text.MessageFormat;
 import java.util.Locale;
@@ -67,7 +68,7 @@ public class MinecraftTranslationRegistry extends TranslatableComponentRenderer<
         localeString = localeString.replace("'", "''");
 
         // Escape all left curly brackets with single quote - fixes https://github.com/GeyserMC/Geyser/issues/4662
-        localeString = escapeBraces(localeString);
+        localeString = MessageTranslator.escapeBraces(localeString);
 
         // Replace the `%s` with numbered inserts `{0}`
         Pattern p = stringReplacement;
@@ -91,37 +92,5 @@ public class MinecraftTranslationRegistry extends TranslatableComponentRenderer<
 
         // Locale shouldn't need to be specific - dates for example will not be handled
         return new MessageFormat(sb.toString(), Locale.ROOT);
-    }
-
-    private String escapeBraces(String origin) {
-        boolean first = true;
-        String splited = origin;
-        StringBuilder sb = null;
-        while (true) {
-            // Get the index of the nearest brace
-            int braceIndex = splited.indexOf("{"); // Only left braces need to be escaped
-            // Append from the content that splited by the braces
-            if (braceIndex == -1) {
-                // Return the result after the last brace
-                return first ? origin : sb.append("'").append(splited).toString();
-            }
-            if (first) {
-                sb = new StringBuilder();
-            }
-            String appendContent = splited.substring(0, braceIndex);
-            // Append single quote on both sides of the braces area or the single quote area that enclosed by braces
-            boolean inBracket = first || braceIndex == 0 || Pattern.matches("'+", appendContent);
-            if (!inBracket) {
-                sb.append("'");
-            }
-            sb.append(appendContent);
-            if (!inBracket || first) {
-                sb.append("'");
-            }
-            sb.append("{");
-            // The next one starts after the current braces
-            splited = splited.substring(braceIndex + 1);
-            first = false;
-        }
     }
 }

--- a/core/src/main/java/org/geysermc/geyser/text/MinecraftTranslationRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/text/MinecraftTranslationRegistry.java
@@ -28,7 +28,6 @@ package org.geysermc.geyser.text;
 import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.jetbrains.annotations.NotNull;
 
 import java.text.MessageFormat;
 import java.util.Locale;
@@ -68,9 +67,7 @@ public class MinecraftTranslationRegistry extends TranslatableComponentRenderer<
         localeString = localeString.replace("'", "''");
 
         // Escape all left curly brackets with single quote - fixes https://github.com/GeyserMC/Geyser/issues/4662
-        if (localeString.contains("{")) {
-            localeString = escapeBraces(localeString);
-        }
+        localeString = escapeBraces(localeString);
 
         // Replace the `%s` with numbered inserts `{0}`
         Pattern p = stringReplacement;
@@ -96,24 +93,24 @@ public class MinecraftTranslationRegistry extends TranslatableComponentRenderer<
         return new MessageFormat(sb.toString(), Locale.ROOT);
     }
 
-    private @NotNull String escapeBraces(String origin) {
+    private String escapeBraces(String origin) {
         boolean first = true;
         String splited = origin;
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = null;
         while (true) {
             // Get the index of the nearest brace
             int braceIndex = splited.indexOf("{"); // Only left braces need to be escaped
             // Append from the content that splited by the braces
             if (braceIndex == -1) {
                 // Return the result after the last brace
-                if (!first) {
-                    sb.append("'");
-                }
-                return sb.append(splited).toString();
+                return first ? origin : sb.append("'").append(splited).toString();
+            }
+            if (first) {
+                sb = new StringBuilder();
             }
             String appendContent = splited.substring(0, braceIndex);
             // Append single quote on both sides of the braces area or the single quote area that enclosed by braces
-            boolean inBracket = first || braceIndex == 0 || appendContent.matches("'+");
+            boolean inBracket = first || braceIndex == 0 || Pattern.matches("'+", appendContent);
             if (!inBracket) {
                 sb.append("'");
             }

--- a/core/src/main/java/org/geysermc/geyser/text/MinecraftTranslationRegistry.java
+++ b/core/src/main/java/org/geysermc/geyser/text/MinecraftTranslationRegistry.java
@@ -67,8 +67,8 @@ public class MinecraftTranslationRegistry extends TranslatableComponentRenderer<
         // replace single quote instances which get lost in MessageFormat otherwise
         localeString = localeString.replace("'", "''");
 
-        // Escape all curly brackets with single quote - fixes https://github.com/GeyserMC/Geyser/issues/4662
-        if (localeString.contains("{") || localeString.contains("}")) {
+        // Escape all left curly brackets with single quote - fixes https://github.com/GeyserMC/Geyser/issues/4662
+        if (localeString.contains("{")) {
             localeString = escapeBraces(localeString);
         }
 
@@ -102,21 +102,17 @@ public class MinecraftTranslationRegistry extends TranslatableComponentRenderer<
         StringBuilder sb = new StringBuilder();
         while (true) {
             // Get the index of the nearest brace
-            int braceIndexL = splited.indexOf("{");
-            int braceIndexR = splited.indexOf("}");
-            int braceIndex = (braceIndexL == -1 && braceIndexR != -1) ? braceIndexR :
-                    (braceIndexL != -1 && braceIndexR == -1) ? braceIndexL :
-                    Math.min(braceIndexL, braceIndexR);
-            // Append from the content after the last brace and return the result
+            int braceIndex = splited.indexOf("{"); // Only left braces need to be escaped
+            // Append from the content that splited by the braces
             if (braceIndex == -1) {
+                // Return the result after the last brace
                 if (!first) {
                     sb.append("'");
                 }
-                sb.append(splited);
-                return sb.toString();
+                return sb.append(splited).toString();
             }
-            // Append from each content between braces
             String appendContent = splited.substring(0, braceIndex);
+            // Append single quote on both sides of the braces area or the single quote area that enclosed by braces
             boolean inBracket = first || braceIndex == 0 || appendContent.matches("'+");
             if (!inBracket) {
                 sb.append("'");
@@ -125,7 +121,7 @@ public class MinecraftTranslationRegistry extends TranslatableComponentRenderer<
             if (!inBracket || first) {
                 sb.append("'");
             }
-            sb.append(braceIndexL == braceIndex ? "{" : "}");
+            sb.append("{");
             // The next one starts after the current braces
             splited = splited.substring(braceIndex + 1);
             first = false;

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -500,7 +500,7 @@ public class MessageTranslator {
             } else {
                 String translateKey = map.getString("translate", null);
                 if (translateKey != null) {
-                    String fallback = map.getString("fallback", "");
+                    String fallback = map.getString("fallback", null);
                     List<Component> args = new ArrayList<>();
 
                     Object with = map.get("with");

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -458,6 +458,7 @@ public class MessageTranslator {
 
     /**
      * Escape All left curly braces to make MessageFormat ignore them
+     *
      * @param origin Text to escape
      * @return Text with left curly braces enclosed by single quotes
      */
@@ -476,6 +477,7 @@ public class MessageTranslator {
                 sb = new StringBuilder();
             }
             String appendContent = origin.substring(0, braceIndex);
+
             // Append single quote on both sides of the braces area or the single quote area that enclosed by braces
             boolean inBracket = first || braceIndex == 0 || Pattern.matches("'+", appendContent);
             if (!inBracket) {
@@ -486,6 +488,7 @@ public class MessageTranslator {
                 sb.append("'");
             }
             sb.append("{");
+
             // The next one starts after the current braces
             origin = origin.substring(braceIndex + 1);
             first = false;

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -77,6 +77,9 @@ public class MessageTranslator {
     private static final String RESET = BASE + "r";
     private static final Pattern RESET_PATTERN = Pattern.compile("(" + RESET + "){2,}");
 
+    // Continuous single quotes character
+    private static final Pattern SINGLE_QUOTES_PATTERN = Pattern.compile("'+");
+
     static {
         // Temporary fix for https://github.com/KyoriPowered/adventure/issues/447 - TODO resolve properly
         GsonComponentSerializer source = DefaultComponentSerializer.get()
@@ -479,7 +482,7 @@ public class MessageTranslator {
             String appendContent = origin.substring(0, braceIndex);
 
             // Append single quote on both sides of the braces area or the single quote area that enclosed by braces
-            boolean inBracket = first || braceIndex == 0 || Pattern.matches("'+", appendContent);
+            boolean inBracket = first || braceIndex == 0 || SINGLE_QUOTES_PATTERN.matcher(appendContent).matches();
             if (!inBracket) {
                 sb.append("'");
             }

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -471,17 +471,21 @@ public class MessageTranslator {
         while (true) {
             // Get the index of the nearest brace
             int braceIndex = origin.indexOf("{"); // Only left braces need to be escaped
-            // Append from the content that split by the braces
+
+            // After the last brace or have not any braces need to be escaped in the content
             if (braceIndex == -1) {
                 // Return the result after the last brace
                 return first ? origin : sb.append("'").append(origin).toString();
             }
+
+            // Initial StringBuilder to splice strings only if the content contains braces
             if (first) {
                 sb = new StringBuilder();
             }
-            String appendContent = origin.substring(0, braceIndex);
 
-            // Append single quote on both sides of the braces area or the single quote area that enclosed by braces
+            // Append from the content that split by the braces
+            String appendContent = origin.substring(0, braceIndex);
+            // Append single quote on both sides of the continuous braces or the continuous single quotes that enclosed by braces
             boolean inBracket = first || braceIndex == 0 || SINGLE_QUOTES_PATTERN.matcher(appendContent).matches();
             if (!inBracket) {
                 sb.append("'");

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -77,9 +77,6 @@ public class MessageTranslator {
     private static final String RESET = BASE + "r";
     private static final Pattern RESET_PATTERN = Pattern.compile("(" + RESET + "){2,}");
 
-    // Continuous single quotes character
-    private static final Pattern SINGLE_QUOTES_PATTERN = Pattern.compile("'+");
-
     static {
         // Temporary fix for https://github.com/KyoriPowered/adventure/issues/447 - TODO resolve properly
         GsonComponentSerializer source = DefaultComponentSerializer.get()
@@ -457,49 +454,6 @@ public class MessageTranslator {
             return "";
         }
         return new String(newChars, 0, count - (whitespacesCount > 0 ? 1 : 0)).trim();
-    }
-
-    /**
-     * Escape All left curly braces to make MessageFormat ignore them
-     *
-     * @param origin Text to escape
-     * @return Text with left curly braces enclosed by single quotes
-     */
-    public static String escapeBraces(String origin) {
-        boolean first = true;
-        StringBuilder sb = null;
-        while (true) {
-            // Get the index of the nearest brace
-            int braceIndex = origin.indexOf("{"); // Only left braces need to be escaped
-
-            // After the last brace or have not any braces need to be escaped in the content
-            if (braceIndex == -1) {
-                // Return the result after the last brace
-                return first ? origin : sb.append("'").append(origin).toString();
-            }
-
-            // Initial StringBuilder to splice strings only if the content contains braces
-            if (first) {
-                sb = new StringBuilder();
-            }
-
-            // Append from the content that split by the braces
-            String appendContent = origin.substring(0, braceIndex);
-            // Append single quote on both sides of the continuous braces or the continuous single quotes that enclosed by braces
-            boolean inBracket = first || braceIndex == 0 || SINGLE_QUOTES_PATTERN.matcher(appendContent).matches();
-            if (!inBracket) {
-                sb.append("'");
-            }
-            sb.append(appendContent);
-            if (!inBracket || first) {
-                sb.append("'");
-            }
-            sb.append("{");
-
-            // The next one starts after the current braces
-            origin = origin.substring(braceIndex + 1);
-            first = false;
-        }
     }
 
     /**

--- a/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
+++ b/core/src/main/java/org/geysermc/geyser/translator/text/MessageTranslator.java
@@ -457,6 +457,42 @@ public class MessageTranslator {
     }
 
     /**
+     * Escape All left curly braces to make MessageFormat ignore them
+     * @param origin Text to escape
+     * @return Text with left curly braces enclosed by single quotes
+     */
+    public static String escapeBraces(String origin) {
+        boolean first = true;
+        StringBuilder sb = null;
+        while (true) {
+            // Get the index of the nearest brace
+            int braceIndex = origin.indexOf("{"); // Only left braces need to be escaped
+            // Append from the content that split by the braces
+            if (braceIndex == -1) {
+                // Return the result after the last brace
+                return first ? origin : sb.append("'").append(origin).toString();
+            }
+            if (first) {
+                sb = new StringBuilder();
+            }
+            String appendContent = origin.substring(0, braceIndex);
+            // Append single quote on both sides of the braces area or the single quote area that enclosed by braces
+            boolean inBracket = first || braceIndex == 0 || Pattern.matches("'+", appendContent);
+            if (!inBracket) {
+                sb.append("'");
+            }
+            sb.append(appendContent);
+            if (!inBracket || first) {
+                sb.append("'");
+            }
+            sb.append("{");
+            // The next one starts after the current braces
+            origin = origin.substring(braceIndex + 1);
+            first = false;
+        }
+    }
+
+    /**
      * Deserialize an NbtMap with a description text component (usually provided from a registry) into a Bedrock-formatted string.
      */
     public static String deserializeDescription(GeyserSession session, NbtMap tag) {

--- a/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
+++ b/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -99,13 +98,6 @@ public class MessageTranslatorTest {
         Assertions.assertEquals("Strange", MessageTranslator.convertToPlainTextLenient("§rStrange", "en_US"), "Valid lenient JSON is not handled properly");
         Assertions.assertEquals("", MessageTranslator.convertToPlainTextLenient("", "en_US"), "Empty message is not handled properly");
         Assertions.assertEquals("     ", MessageTranslator.convertToPlainTextLenient("     ", "en_US"), "Whitespace is not preserved");
-    }
-
-    @Test
-    public void escapeBraces() {
-        Assertions.assertEquals("tt{ttAAtt}tt", new MessageFormat(MessageTranslator.escapeBraces("tt{tt%stt}tt".replace("'", "''")).replace("%s", "{0}")).format(new Object[]{"AA"}), "Braces that should be escaped are not handled properly");
-        Assertions.assertEquals("tt{''{tt", new MessageFormat(MessageTranslator.escapeBraces("tt{''{tt".replace("'", "''")).replace("%s", "{0}")).format(new Object[]{"AA"}), "Braces that should be escaped are not handled properly");
-        Assertions.assertEquals("tt{{''}}tt", new MessageFormat(MessageTranslator.escapeBraces("tt{{''}}tt".replace("'", "''")).replace("%s", "{0}")).format(new Object[]{"AA"}), "Braces that should be escaped are not handled properly");
     }
 
     @Test

--- a/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
+++ b/core/src/test/java/org/geysermc/geyser/network/translators/chat/MessageTranslatorTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,6 +99,13 @@ public class MessageTranslatorTest {
         Assertions.assertEquals("Strange", MessageTranslator.convertToPlainTextLenient("§rStrange", "en_US"), "Valid lenient JSON is not handled properly");
         Assertions.assertEquals("", MessageTranslator.convertToPlainTextLenient("", "en_US"), "Empty message is not handled properly");
         Assertions.assertEquals("     ", MessageTranslator.convertToPlainTextLenient("     ", "en_US"), "Whitespace is not preserved");
+    }
+
+    @Test
+    public void escapeBraces() {
+        Assertions.assertEquals("tt{ttAAtt}tt", new MessageFormat(MessageTranslator.escapeBraces("tt{tt%stt}tt".replace("'", "''")).replace("%s", "{0}")).format(new Object[]{"AA"}), "Braces that should be escaped are not handled properly");
+        Assertions.assertEquals("tt{''{tt", new MessageFormat(MessageTranslator.escapeBraces("tt{''{tt".replace("'", "''")).replace("%s", "{0}")).format(new Object[]{"AA"}), "Braces that should be escaped are not handled properly");
+        Assertions.assertEquals("tt{{''}}tt", new MessageFormat(MessageTranslator.escapeBraces("tt{{''}}tt".replace("'", "''")).replace("%s", "{0}")).format(new Object[]{"AA"}), "Braces that should be escaped are not handled properly");
     }
 
     @Test


### PR DESCRIPTION
# Escape curly braces correctly in translation strings
A better solution of GeyserMC#4662

## Example
- `---`: Escaped by MessageFormat
- `^^^`: Reason of problems

### `{translate: "tt{tt%stt}tt", with: ["AA"]}`
During process:
```
tt'{tt%stt'}tt
  ---------
```
Result: ![image](https://github.com/user-attachments/assets/12242640-d3d5-4b57-9009-8231bee44834)
### After this fixes
During process:
```
tt'{'tt%stt}tt
  ---
```
Result: ![image](https://github.com/user-attachments/assets/7622ea57-68d9-4b8e-9441-813198bb1a87)

### `{translate: "tt{''{tt"}`
During process:
```
tt'{'''''{tt
  -------^^^
```
Result: `java.lang.IllegalArgumentException: Unmatched braces in the pattern.`
### After this fixes
During process:
```
tt'{''''{'tt
  --------
```
Result: ![image](https://github.com/user-attachments/assets/613868e3-4106-4cde-9249-55c9cceec373)

### `{translate: "tt{{''}}tt"}`
During process:
```
tt'{'{'''''}'}tt
  --- ^^^^^^^
```
Result: `java.lang.IllegalArgumentException: can't parse argument number: '''''}'`
### After this fixes
During process:
```
tt'{{'''''}}tt
  --------
```
Result: ![image](https://github.com/user-attachments/assets/577809fe-34e1-408d-91c9-43aac70b8f51)

# Default translation fallback should not appear in the text component

Java Edition allows the use of translation text component anywhere without localization key, For example it can use placeholders `%s` directly in text components. Since Geyser support 1.21.5, an empty string is provided in the sign text as the default fallback, which has causing this problem.

## Example

`/setblock ~ ~ ~ oak_sign{front_text: {messages: [{translate: "Test on %s", with: [{translate: "block.minecraft.oak_sign"}]}, "", "", ""]}}`

Original:
![image](https://github.com/user-attachments/assets/d3e88598-9376-487a-84ed-b5027f3722d9)

**After this fixes: (same as Java Edition)**
![image](https://github.com/user-attachments/assets/f996ffbe-782e-44eb-8a8b-424e73a1a957)